### PR TITLE
feat: Add templates for issue and pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Report a bug in capa.io
+title: ''
+labels: kind/bug
+assignees: ''
+---
+
+- [ ] I have searched the [issues](https://github.com/reactivegroup/capa.io/issues) of this repository and believe that this is not a duplicate.
+
+## Expected Behavior
+
+<!-- Briefly describe what you expect to happen -->
+
+
+## Actual Behavior
+
+<!-- Briefly describe what is actually happening -->

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,9 @@
+---
+name: Discussion
+about: Start a discussion for capa.io
+title: ''
+labels: kind/discussion
+assignees: ''
+
+---
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature Request
+about: Create a Feature Request for capa.io
+title: ''
+labels: kind/enhancement
+assignees: ''
+
+---
+## Describe the feature

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,9 @@
+---
+name: Proposal
+about: Create a proposal for Capa
+title: ''
+labels: kind/proposal
+assignees: ''
+
+---
+## Describe the proposal

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question about capa.io
+title: ''
+labels: kind/question
+assignees: ''
+
+---
+
+## Ask your question here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# Description
+
+_Please explain the changes you've made_
+
+## Issue reference
+
+We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
+
+Please reference the issue this PR will close: #_[issue number]_


### PR DESCRIPTION
1. Supports template for reporting bug
2. Supports template for discussion
3. Supports template for requesting feature
4. Supports template for proposal
5. Supports template for question

see issue: https://github.com/reactivegroup/capa.io/issues/11