### PR TITLE
fix: Fix the bug on typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,6 +1,6 @@
 ---
 name: Proposal
-about: Create a proposal for Capa
+about: Create a proposal for capa.io
 title: ''
 labels: kind/proposal
 assignees: ''


### PR DESCRIPTION
# Description

Change `Capa` to `capa.io`

## Issue reference

see issue: https://github.com/reactivegroup/capa.io/issues/15

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[15]_
